### PR TITLE
Remove soft deleted items (mongoose-delete) from Algolia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,18 @@ mappings: {
 
 *You can nest properties*
 
+#### softdelete
+You can enable softdeletion support (like [mongoose-delete](https://github.com/dsanel/mongoose-delete)) by setting `softdelete` to true.
+
+As a result, all documents updated with a property `deleted: true` will be removed from Algolia.
+
+
 #### debug
 You can enable logging of all operations by setting `debug` to true
 
-###Methods
+### Methods
 
-####SyncToAlgolia
+#### SyncToAlgolia
 
 Call this method if you want to sync all your documents with algolia
 
@@ -144,7 +150,7 @@ This method clears the Algolia index for this schema and synchronizes all docume
 Model.SyncToAlgolia();
 ```
 
-####SetAlgoliaSettings
+#### SetAlgoliaSettings
 
 Sets the settings for this schema, see [Algolia's Index settings parameters](https://www.algolia.com/doc/api-client/javascript/settings#set-settings) for more info about available parameters.
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ module.exports = exports = function algoliaIntegration(schema,opts) {
     defaults: null,
     mappings: null,
     populate: null,
+    softdelete: false,
     debug: false
   }
 

--- a/src/operations.js
+++ b/src/operations.js
@@ -44,7 +44,9 @@ module.exports = function(options,client){
   }
 
   function SyncItem(context, index){
-    if(context.wasNew) {
+    if(options.softdelete && context.deleted) {
+      RemoveItem(context, index);
+    } else if(context.wasNew) {
       utils.ApplyPopulation(context,options.populate).then(populated => {
         index.addObject(populated.toObject({
           versionKey: false,
@@ -63,8 +65,6 @@ module.exports = function(options,client){
       }).catch(err => {
         console.error(clc.blackBright(`[${new Date().toLocaleTimeString()}]`),clc.cyanBright('[Algolia-sync]'),' -> ',clc.red.bold('Error (at population)'),' -> ',err);
       });
-    } else if (context.deleted) {
-      RemoveItem(context, index);
     } else if(context.wasModified){
       utils.ApplyPopulation(context,options.populate).then(populated => {
         index.saveObject(populated.toObject({

--- a/src/operations.js
+++ b/src/operations.js
@@ -63,7 +63,9 @@ module.exports = function(options,client){
       }).catch(err => {
         console.error(clc.blackBright(`[${new Date().toLocaleTimeString()}]`),clc.cyanBright('[Algolia-sync]'),' -> ',clc.red.bold('Error (at population)'),' -> ',err);
       });
-    }else if(context.wasModified){
+    } else if (context.deleted) {
+      RemoveItem(context, index);
+    } else if(context.wasModified){
       utils.ApplyPopulation(context,options.populate).then(populated => {
         index.saveObject(populated.toObject({
           versionKey: false,


### PR DESCRIPTION
Hi !
[mongoose-delete](https://github.com/dsanel/mongoose-delete) brings soft-deletion to Mongoose.
This PR brings soft-deletion support to mongoose-algolia. Considering the soft deletion of a Document like a removal from Algolia.
Restoring a Document works too, as it enters the update workflow.
(this tells me the pre save logic is actually optional and could be removed if overhead becomes an issue).
Thanks for this package I hope this PR helps.
