### PR TITLE
Remove unneded values after making changes

### DIFF
--- a/src/operations.js
+++ b/src/operations.js
@@ -58,10 +58,13 @@ module.exports = function(options,client){
           transform: function(doc,ret) {
             if (doc.constructor.modelName !== populated.constructor.modelName) return ret;
 
-            delete ret._id;
+
             ret = utils.ApplyVirtuals(ret, options.virtuals);
             ret = utils.ApplyMappings(ret, options.mappings);
             ret = utils.ApplyDefaults(ret, options.defaults);
+
+            delete ret._id;
+
             return utils.ApplySelector(ret,options.selector);
           }
         }),context._id,(err,content) => {
@@ -78,12 +81,13 @@ module.exports = function(options,client){
           transform: function(doc,ret) {
             if (doc.constructor.modelName !== populated.constructor.modelName) return ret;
 
-            delete ret._id;
+
             ret = utils.ApplyVirtuals(ret, options.virtuals);
             ret = utils.ApplyMappings(ret, options.mappings);
             ret = utils.ApplyDefaults(ret, options.defaults);
             ret = utils.ApplySelector(ret,options.selector);
 
+            delete ret._id;
             ret.objectID = doc._id;
 
             return ret;

--- a/src/synchronize.js
+++ b/src/synchronize.js
@@ -58,13 +58,14 @@ module.exports = function(options,client){
                 transform: function(doc,ret) {
                   if (doc.constructor.modelName !== obj.constructor.modelName) return ret;
 
-                  delete ret._id;
-                  delete ret.__v;
+
                   ret = utils.ApplyVirtuals(ret, options.virtuals);
                   ret = utils.ApplyMappings(ret, options.mappings);
                   ret = utils.ApplyDefaults(ret, options.defaults);
                   ret = utils.ApplySelector(ret,options.selector);
 
+                  delete ret._id;
+                  delete ret.__v;
                   ret.objectID = doc._id;
 
                   return ret;


### PR DESCRIPTION
Hi, and thanks for this package! I'm actually don't know why did you decide to remove "_id" value, but I have one issue. One of my collections has "_id" field with string type. I need to create a virtual field using "_id". 

So, I propose to remove it after making modifications.